### PR TITLE
FIX: remove eggs from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ build/
 develop-eggs/
 dist/
 downloads/
-eggs/
-.eggs/
 lib/
 lib64/
 parts/
@@ -24,7 +22,6 @@ pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
-*.egg
 MANIFEST
 
 # PyInstaller


### PR DESCRIPTION
Eggs need to be tracked.
As an egg owner, I find the inclusion of `eggs` strings in  `.gitignore`  offensive and disrespectful.