### PR TITLE
Fix __init__ file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 per-file-ignores =
-    __init__.py:F401
+
 
 max-complexity = 20
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = "0.0.7"
+version = "0.0.8"
 
 setuptools.setup(
     name="shpyx",

--- a/shpyx/__init__.py
+++ b/shpyx/__init__.py
@@ -1,3 +1,14 @@
+__all__ = [
+    # From .cmd_runner
+    "ShellCmdRunner",
+    "run",
+    # From .errors
+    "InternalError",
+    "VerificationError",
+    # From .result
+    "ShellCmdResult",
+]
+
 from .cmd_runner import ShellCmdRunner, run
 from .errors import InternalError, VerificationError
 from .result import ShellCmdResult


### PR DESCRIPTION
Add `__all__` in `__init__.py` to avoid type errors when running mypy strictly.