### PR TITLE
Remove --echo from unix_raw execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool.poetry]
 name = "shpyx"
 packages = [{include = "shpyx"}]
-version = "0.0.31"
+version = "0.0.32"
 description = "Run shell commands in Python"
 authors = ["Yossi Rozantsev"]
 license = "MIT"

--- a/shpyx/runner.py
+++ b/shpyx/runner.py
@@ -235,7 +235,7 @@ class Runner:
                 if _SYSTEM == "Linux":
                     # Old format: https://linux.die.net/man/1/script
                     # New format: https://man7.org/linux/man-pages/man1/script.1.html
-                    args = f"script --echo always --return --quiet --command {shlex.quote(cmd_str)} {tmp_file.name}"
+                    args = f"script --return --quiet --command {shlex.quote(cmd_str)} {tmp_file.name}"
                 elif _SYSTEM == "Darwin":
                     # MacOS format: https://keith.github.io/xcode-man-pages/script.1.html
                     args = f"script -q {tmp_file.name} {cmd_str}"


### PR DESCRIPTION
Remove the `--echo` argument, which is not necessary and just logs the same input twice.
Was added by accident in https://github.com/Apakottur/shpyx/pull/45