### PR TITLE
Fix README errors and clean up runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ShellCmdResult(cmd='echo 1', stdout='1\n', stderr='', all_output='1\n', return_c
 In list format:
 
 ```python
->>> shpyx.run(["echo", ["1"])
+>>> shpyx.run(["echo", "1"])
 ShellCmdResult(cmd='echo 1', stdout='1\n', stderr='', all_output='1\n', return_code=0)
 ```
 
@@ -97,7 +97,7 @@ colors. For example, the `psql` command is used to start an interactive shell ag
 shpyx.run(f"psql -h {host} -p {port} -U {user} -d {database}", log_output=True)
 ```
 
-However, the above call will not work as good as running `psql` directly, due to terminal control sequences not being
+However, the above call will not work as well as running `psql` directly, due to terminal control sequences not being
 properly propagated. To make it work well, we need to use the [script](https://man7.org/linux/man-pages/man1/script.1.html)
 utility which will properly propagate all control sequences:
 
@@ -105,7 +105,7 @@ utility which will properly propagate all control sequences:
 # Linux:
 shpyx.run(f"script -q -c 'psql -h {host} -p {port} -U {user} -d {database}'", log_output=True)
 # MacOS:
-shpyx.run(f"script -q psql -h {host} -p {port} -U {user} -d {database}", log_output=True)
+shpyx.run(f"script -q /dev/null psql -h {host} -p {port} -U {user} -d {database}", log_output=True)
 
 ```
 
@@ -185,7 +185,7 @@ Tests, linters and type checks are run in CI through GitHub Actions.
 To run checks locally, start by installing all the development dependencies:
 
 ```shell
-poetry install
+uv sync
 ```
 
 To run the linters use `pre-commit`:
@@ -203,7 +203,13 @@ pytest -c tests/pytest.ini tests
 To run type checks use `mypy`:
 
 ```shell
-mypy --config-file shpyx/mypy.toml shpyx tests
+mypy --config-file linters/mypy.toml src tests
+```
+
+and `ty`:
+
+```shell
+ty check --config-file linters/ty.toml src tests
 ```
 
 To trigger a deployment of a new version upon merge, bump the version number in `pyproject.toml`.

--- a/src/runner.py
+++ b/src/runner.py
@@ -273,11 +273,13 @@ class Runner:
                 cwd=exec_dir,
             )
         except Exception as e:
-            raise ShpyxInternalError("Failed to initialize subprocess.") from e
+            raise ShpyxInternalError("Failed to initialize subprocess (subprocess.Popen)") from e
 
         # Verify that all the pipes were properly configured.
-        if not (p.stdout and p.stderr):  # pragma: no cover
-            raise ShpyxInternalError("Failed to initialize subprocess.")
+        if not p.stdout:
+            raise ShpyxInternalError("Failed to initialize subprocess (stdout pipe)")
+        if not p.stderr:
+            raise ShpyxInternalError("Failed to initialize subprocess (stderr pipe)")
 
         # Initialize the result object.
         result = ShellCmdResult(cmd=cmd_str)

--- a/src/runner.py
+++ b/src/runner.py
@@ -29,16 +29,15 @@ def _is_action_required(*, user: bool | None, default: bool) -> bool:
     Returns whether an action needs to be done, based on whether the user required it and the default value of the
     runner.
     """
-    match user:
-        case True:
-            # The user explicitly set the value to `True`.
-            return True
-        case False:
-            # The user explicitly set the value to `False`.
-            return False
-        case None:
-            # The user did not provide a value for the action, use the default.
-            return default
+    if user is True:
+        # The user explicitly set the value to `True`.
+        return True
+    elif user is False:
+        # The user explicitly set the value to `False`.
+        return False
+    else:
+        # The user did not provide a value for the action, use the default.
+        return default
 
 
 class Runner:
@@ -274,11 +273,11 @@ class Runner:
                 cwd=exec_dir,
             )
         except Exception as e:
-            raise ShpyxInternalError("Failed to initialize subprocess") from e
+            raise ShpyxInternalError("Failed to initialize subprocess.") from e
 
         # Verify that all the pipes were properly configured.
-        if not (p.stdout and p.stderr):
-            raise ShpyxInternalError("Failed to initialize subprocess")
+        if not (p.stdout and p.stderr):  # pragma: no cover
+            raise ShpyxInternalError("Failed to initialize subprocess.")
 
         # Initialize the result object.
         result = ShellCmdResult(cmd=cmd_str)

--- a/src/runner.py
+++ b/src/runner.py
@@ -29,20 +29,21 @@ def _is_action_required(*, user: bool | None, default: bool) -> bool:
     Returns whether an action needs to be done, based on whether the user required it and the default value of the
     runner.
     """
-    if user is True:
-        # The user explicitly set the value to `True`.
-        return True
-    elif user is False:
-        # The user explicitly set the value to `False`.
-        return False
-    else:
-        # The user did not provide a value for the action, use the default.
-        return default
+    match user:
+        case True:
+            # The user explicitly set the value to `True`.
+            return True
+        case False:
+            # The user explicitly set the value to `False`.
+            return False
+        case None:
+            # The user did not provide a value for the action, use the default.
+            return default
 
 
 class Runner:
     """
-    An instance of a shell command runner, used to run shell commands based on a specific configuration.
+    An instance of a shell command runner, used to run shell commands with a specific runner configuration.
     """
 
     def __init__(
@@ -187,20 +188,21 @@ class Runner:
         self,
         args: str | list[str],
         *,
+        # Runner configuration.
         log_cmd: bool | None = None,
         log_output: bool | None = None,
         verify_return_code: bool | None = None,
         verify_stderr: bool | None = None,
         use_signal_names: bool | None = None,
+        # Command execution configuration.
         env: dict[str, str] | None = None,
         exec_dir: Path | str | None = None,
-        unix_raw: bool | None = False,
+        unix_raw: bool = False,
     ) -> ShellCmdResult:
         """
         Run a shell command.
 
         Apart from the command itself, all arguments are optional.
-        The default values of the arguments can be found in `ShellCmdRunnerConfig`.
 
         Args:
             args: The shell command arguments, can be a string (with the full command) or a list of strings.
@@ -271,12 +273,12 @@ class Runner:
                 env=cmd_env,
                 cwd=exec_dir,
             )
-        except Exception:
-            p = None
+        except Exception as e:
+            raise ShpyxInternalError("Failed to initialize subprocess") from e
 
         # Verify that all the pipes were properly configured.
-        if not (p and p.stdout and p.stderr):
-            raise ShpyxInternalError("Failed to initialize subprocess.")
+        if not (p.stdout and p.stderr):
+            raise ShpyxInternalError("Failed to initialize subprocess")
 
         # Initialize the result object.
         result = ShellCmdResult(cmd=cmd_str)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,9 @@ Test the default runner, `shpyx.run`.
 
 import platform
 import signal
+import subprocess
 import tempfile
+from enum import Enum, auto
 from pathlib import Path
 
 import pytest
@@ -162,16 +164,41 @@ def test_exec_dir() -> None:
         _verify_result(result, return_code=0, stdout="avocado", stderr="")
 
 
-def test_fail_to_initialize_subprocess(mocker: pytest_mock.MockerFixture) -> None:
-    def _popen(*_args: str, **_kwargs: str) -> None:
-        raise OSError("Some SO error")
+class _SubprocessPopenIssue(Enum):
+    CRASH = auto()
+    STDOUT_PIPE_MISSING = auto()
+    STDERR_PIPE_MISSING = auto()
+
+
+@pytest.mark.parametrize("issue", _SubprocessPopenIssue)
+def test_fail_to_initialize_subprocess(mocker: pytest_mock.MockerFixture, issue: _SubprocessPopenIssue) -> None:
+    orig = subprocess.Popen
+
+    def _popen(*args: str, **kwargs: str) -> None:
+        match issue:
+            case _SubprocessPopenIssue.CRASH:
+                raise OSError("Some SO error")
+            case _SubprocessPopenIssue.STDOUT_PIPE_MISSING:
+                p = orig(*args, **kwargs)
+                p.stdout = None
+                return p
+            case _SubprocessPopenIssue.STDERR_PIPE_MISSING:
+                p = orig(*args, **kwargs)
+                p.stderr = None
+                return p
 
     mocker.patch("src.runner.subprocess.Popen", _popen)
 
     with pytest.raises(shpyx.ShpyxInternalError) as exc:
         shpyx.run("echo 1")
 
-    assert str(exc.value) == "Failed to initialize subprocess."
+    match issue:
+        case _SubprocessPopenIssue.CRASH:
+            assert str(exc.value) == "Failed to initialize subprocess (subprocess.Popen)"
+        case _SubprocessPopenIssue.STDOUT_PIPE_MISSING:
+            assert str(exc.value) == "Failed to initialize subprocess (stdout pipe)"
+        case _SubprocessPopenIssue.STDERR_PIPE_MISSING:
+            assert str(exc.value) == "Failed to initialize subprocess (stderr pipe)"
 
 
 def test_signal_names_enabled() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 from enum import Enum, auto
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytest_mock
@@ -174,7 +175,7 @@ class _SubprocessPopenIssue(Enum):
 def test_fail_to_initialize_subprocess(mocker: pytest_mock.MockerFixture, issue: _SubprocessPopenIssue) -> None:
     orig = subprocess.Popen
 
-    def _popen(*args: str, **kwargs: str) -> None:
+    def _popen(*args: Any, **kwargs: Any) -> Any:
         match issue:
             case _SubprocessPopenIssue.CRASH:
                 raise OSError("Some SO error")


### PR DESCRIPTION
## README
- Fix broken list-format example (`["echo", ["1"]` — mismatched brackets)
- Add missing output-file arg to macOS `script` example (`script -q /dev/null ...`)
- "as good as" → "as well as"
- `poetry install` → `uv sync` (repo migrated to uv)
- Correct mypy config path/targets (`linters/mypy.toml src tests`) and add `ty` type-check command

## runner.py
- Chain original exception when subprocess init fails — previously swallowed with `p = None`, hiding the real cause (e.g. `FileNotFoundError`) behind a generic error
- `unix_raw` type `bool | None` → `bool`
- Minor docstring/comment tidy-ups

Tests pass with 100% coverage; `mypy` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)