### PR TITLE
Decode output incrementally, with a configurable decoder

### DIFF
--- a/linters/cspell/words.txt
+++ b/linters/cspell/words.txt
@@ -32,3 +32,4 @@ nonblock
 pathlib
 anyio
 multibyte
+haia

--- a/linters/cspell/words.txt
+++ b/linters/cspell/words.txt
@@ -31,3 +31,4 @@ pythonpath
 nonblock
 pathlib
 anyio
+multibyte

--- a/src/runner.py
+++ b/src/runner.py
@@ -257,8 +257,8 @@ class Runner:
                       This allows capturing all characters from the command output, including cursor movement and
                       colors. This can be useful when the command is an interactive shell, like `psql`.
                       Runner default: `False`.
-            decoder_factory: A zero-argument callable returning a fresh incremental decoder, used to decode the
-                             command output. Overrides the runner default when provided.
+            decoder_factory: Callable that returns a fresh incremental decoder, used to decode the command output.
+                             Runner default: `None`, which uses the default decoder factory.
 
         Returns:
             The result, as a `ShellCmdResult` object.

--- a/src/runner.py
+++ b/src/runner.py
@@ -26,19 +26,17 @@ if _SYSTEM != "Windows":
     import fcntl
 
 
-# A factory that produces a fresh incremental decoder for a single command output stream. A new decoder must be
-# created per stream and per run, since an incremental decoder is stateful (it buffers partial multibyte characters).
-DecoderFactory = Callable[[], codecs.IncrementalDecoder]
+# A callable that returns a fresh incremental decoder for a single command output stream.
+_DecoderFactory = Callable[[], codecs.IncrementalDecoder]
 
 
 def _default_decoder_factory() -> codecs.IncrementalDecoder:
     """
-    The default output decoder factory:
-
-    1. Decodes incrementally, so a valid multibyte character split across two reads (which are not aligned to
-       character boundaries) is held until the next read completes it, rather than raising.
-    2. Uses UTF-8.
-    3. Replaces genuinely invalid bytes (e.g. binary data) with the Unicode replacement character instead of raising.
+    Get the default output decoder factory:
+        1. Decodes incrementally, so a valid multibyte character split across two reads (which are not aligned to
+        character boundaries) is held until the next read completes it, rather than raising.
+        2. Uses UTF-8.
+        3. Replaces genuinely invalid bytes (e.g. binary data) with the Unicode replacement character instead of raising.
     """
     return codecs.getincrementaldecoder("utf-8")(errors="replace")
 
@@ -72,7 +70,7 @@ class Runner:
         verify_return_code: bool = True,
         verify_stderr: bool = False,
         use_signal_names: bool = True,
-        decoder_factory: DecoderFactory = _default_decoder_factory,
+        decoder_factory: _DecoderFactory = _default_decoder_factory,
     ) -> None:
         """
         Create a command runner.
@@ -87,8 +85,7 @@ class Runner:
             verify_stderr: Whether to raise an exception if anything was written to stderr during the execution.
             use_signal_names:  Whether to log the name of the signal corresponding to a non-zero error code,
                                in case of result verification failure.
-            decoder_factory: A zero-argument callable returning a fresh incremental decoder, used to decode the
-                             command output. Defaults to UTF-8 with invalid bytes replaced.
+            decoder_factory: Callable that returns a fresh incremental decoder, used to decode the command output.
         """
         self._log_cmd = log_cmd
         self._log_output = log_output
@@ -109,20 +106,19 @@ class Runner:
         self,
         *,
         result: ShellCmdResult,
-        decoder: codecs.IncrementalDecoder,
         data: bytes | None,
         log_output: bool | None,
-        final: bool = False,
+        decoder: codecs.IncrementalDecoder,
+        final: bool,
     ) -> None:
         """
         Add partial stdout output to the result.
 
         Args:
             result: The result object of the command.
-            decoder: The incremental decoder for this stream, holding any partial multibyte character
-                     from the previous read so it can be completed by the current one.
             data: The partial stdout output to add.
             log_output: Whether to log the output, as supplied to `.run`.
+            decoder: Stream decoder.
             final: Whether this is the last chunk, flushing any trailing incomplete bytes.
         """
         decoded_data = decoder.decode(data or b"", final)
@@ -139,20 +135,19 @@ class Runner:
         self,
         *,
         result: ShellCmdResult,
-        decoder: codecs.IncrementalDecoder,
         data: bytes | None,
         log_output: bool | None,
-        final: bool = False,
+        decoder: codecs.IncrementalDecoder,
+        final: bool,
     ) -> None:
         """
         Add partial stderr output to the result.
 
         Args:
             result: The result object of the command.
-            decoder: The incremental decoder for this stream, holding any partial multibyte character
-                     from the previous read so it can be completed by the current one.
             data: The partial stderr output to add.
             log_output: Whether to log the output, as supplied to `.run`.
+            decoder: Stream decoder.
             final: Whether this is the last chunk, flushing any trailing incomplete bytes.
         """
         decoded_data = decoder.decode(data or b"", final)
@@ -228,7 +223,7 @@ class Runner:
         env: dict[str, str] | None = None,
         exec_dir: Path | str | None = None,
         unix_raw: bool = False,
-        decoder_factory: DecoderFactory | None = None,
+        decoder_factory: _DecoderFactory | None = None,
     ) -> ShellCmdResult:
         """
         Run a shell command.
@@ -332,9 +327,9 @@ class Runner:
         result = ShellCmdResult(cmd=cmd_str)
 
         # Create a fresh decoder per stream (they are stateful and must not be shared).
-        factory = decoder_factory if decoder_factory is not None else self._decoder_factory
-        stdout_decoder = factory()
-        stderr_decoder = factory()
+        decoder_factory = decoder_factory or self._decoder_factory
+        stdout_decoder = decoder_factory()
+        stderr_decoder = decoder_factory()
 
         # Make all the command outputs non-blocking, so that it can be interrupted.
         if _SYSTEM != "Windows":
@@ -356,8 +351,12 @@ class Runner:
             stderr_data = p.stderr.read()
 
             # Add partial outputs to result and log them, if needed.
-            self._add_stdout(result=result, decoder=stdout_decoder, data=stdout_data, log_output=log_output)
-            self._add_stderr(result=result, decoder=stderr_decoder, data=stderr_data, log_output=log_output)
+            self._add_stdout(
+                result=result, decoder=stdout_decoder, data=stdout_data, log_output=log_output, final=False
+            )
+            self._add_stderr(
+                result=result, decoder=stderr_decoder, data=stderr_data, log_output=log_output, final=False
+            )
 
             time.sleep(0.01)
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -27,13 +27,13 @@ if _SYSTEM != "Windows":
 
 
 # A factory that produces a fresh incremental decoder for a single command output stream. A new decoder must be
-# created per stream and per run, as an incremental decoder is stateful (it buffers partial multibyte characters).
+# created per stream and per run, since an incremental decoder is stateful (it buffers partial multibyte characters).
 DecoderFactory = Callable[[], codecs.IncrementalDecoder]
 
 
 def _default_decoder_factory() -> codecs.IncrementalDecoder:
     """
-    The default output decoder:
+    The default output decoder factory:
 
     1. Decodes incrementally, so a valid multibyte character split across two reads (which are not aligned to
        character boundaries) is held until the next read completes it, rather than raising.

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 import os
 import platform
 import shlex
@@ -8,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from src.errors import ShpyxInternalError, ShpyxOSNotSupportedError, ShpyxVerificationError
@@ -22,6 +24,23 @@ _SYSTEM = platform.system()
 
 if _SYSTEM != "Windows":
     import fcntl
+
+
+# A factory that produces a fresh incremental decoder for a single command output stream. A new decoder must be
+# created per stream and per run, as an incremental decoder is stateful (it buffers partial multibyte characters).
+DecoderFactory = Callable[[], codecs.IncrementalDecoder]
+
+
+def _default_decoder_factory() -> codecs.IncrementalDecoder:
+    """
+    The default output decoder:
+
+    1. Decodes incrementally, so a valid multibyte character split across two reads (which are not aligned to
+       character boundaries) is held until the next read completes it, rather than raising.
+    2. Uses UTF-8.
+    3. Replaces genuinely invalid bytes (e.g. binary data) with the Unicode replacement character instead of raising.
+    """
+    return codecs.getincrementaldecoder("utf-8")(errors="replace")
 
 
 def _is_action_required(*, user: bool | None, default: bool) -> bool:
@@ -53,6 +72,7 @@ class Runner:
         verify_return_code: bool = True,
         verify_stderr: bool = False,
         use_signal_names: bool = True,
+        decoder_factory: DecoderFactory = _default_decoder_factory,
     ) -> None:
         """
         Create a command runner.
@@ -67,12 +87,15 @@ class Runner:
             verify_stderr: Whether to raise an exception if anything was written to stderr during the execution.
             use_signal_names:  Whether to log the name of the signal corresponding to a non-zero error code,
                                in case of result verification failure.
+            decoder_factory: A zero-argument callable returning a fresh incremental decoder, used to decode the
+                             command output. Defaults to UTF-8 with invalid bytes replaced.
         """
         self._log_cmd = log_cmd
         self._log_output = log_output
         self._verify_return_code = verify_return_code
         self._verify_stderr = verify_stderr
         self._use_signal_names = use_signal_names
+        self._decoder_factory = decoder_factory
 
     @staticmethod
     def _log(msg: str) -> None:
@@ -86,21 +109,26 @@ class Runner:
         self,
         *,
         result: ShellCmdResult,
+        decoder: codecs.IncrementalDecoder,
         data: bytes | None,
         log_output: bool | None,
+        final: bool = False,
     ) -> None:
         """
         Add partial stdout output to the result.
 
         Args:
             result: The result object of the command.
+            decoder: The incremental decoder for this stream, holding any partial multibyte character
+                     from the previous read so it can be completed by the current one.
             data: The partial stdout output to add.
             log_output: Whether to log the output, as supplied to `.run`.
+            final: Whether this is the last chunk, flushing any trailing incomplete bytes.
         """
-        if not data:
+        decoded_data = decoder.decode(data or b"", final)
+        if not decoded_data:
             return
 
-        decoded_data = data.decode()
         result.stdout += decoded_data
         result.all_output += decoded_data
 
@@ -111,21 +139,26 @@ class Runner:
         self,
         *,
         result: ShellCmdResult,
+        decoder: codecs.IncrementalDecoder,
         data: bytes | None,
         log_output: bool | None,
+        final: bool = False,
     ) -> None:
         """
         Add partial stderr output to the result.
 
         Args:
             result: The result object of the command.
+            decoder: The incremental decoder for this stream, holding any partial multibyte character
+                     from the previous read so it can be completed by the current one.
             data: The partial stderr output to add.
             log_output: Whether to log the output, as supplied to `.run`.
+            final: Whether this is the last chunk, flushing any trailing incomplete bytes.
         """
-        if not data:
+        decoded_data = decoder.decode(data or b"", final)
+        if not decoded_data:
             return
 
-        decoded_data = data.decode()
         result.stderr += decoded_data
         result.all_output += decoded_data
 
@@ -195,6 +228,7 @@ class Runner:
         env: dict[str, str] | None = None,
         exec_dir: Path | str | None = None,
         unix_raw: bool = False,
+        decoder_factory: DecoderFactory | None = None,
     ) -> ShellCmdResult:
         """
         Run a shell command.
@@ -228,6 +262,8 @@ class Runner:
                       This allows capturing all characters from the command output, including cursor movement and
                       colors. This can be useful when the command is an interactive shell, like `psql`.
                       Runner default: `False`.
+            decoder_factory: A zero-argument callable returning a fresh incremental decoder, used to decode the
+                             command output. Overrides the runner default when provided.
 
         Returns:
             The result, as a `ShellCmdResult` object.
@@ -295,6 +331,11 @@ class Runner:
         # Initialize the result object.
         result = ShellCmdResult(cmd=cmd_str)
 
+        # Create a fresh decoder per stream (they are stateful and must not be shared).
+        factory = decoder_factory if decoder_factory is not None else self._decoder_factory
+        stdout_decoder = factory()
+        stderr_decoder = factory()
+
         # Make all the command outputs non-blocking, so that it can be interrupted.
         if _SYSTEM != "Windows":
             fcntl.fcntl(
@@ -315,15 +356,15 @@ class Runner:
             stderr_data = p.stderr.read()
 
             # Add partial outputs to result and log them, if needed.
-            self._add_stdout(result=result, data=stdout_data, log_output=log_output)
-            self._add_stderr(result=result, data=stderr_data, log_output=log_output)
+            self._add_stdout(result=result, decoder=stdout_decoder, data=stdout_data, log_output=log_output)
+            self._add_stderr(result=result, decoder=stderr_decoder, data=stderr_data, log_output=log_output)
 
             time.sleep(0.01)
 
-        # Get the remaining outputs and add them to the result.
+        # Get the remaining outputs and add them to the result, flushing any trailing incomplete bytes.
         final_stdout, final_stderr = p.communicate()
-        self._add_stdout(result=result, data=final_stdout, log_output=log_output)
-        self._add_stderr(result=result, data=final_stderr, log_output=log_output)
+        self._add_stdout(result=result, decoder=stdout_decoder, data=final_stdout, log_output=log_output, final=True)
+        self._add_stderr(result=result, decoder=stderr_decoder, data=final_stderr, log_output=log_output, final=True)
 
         # Cleanup.
         p.stdout.close()

--- a/tests/fake_proc.py
+++ b/tests/fake_proc.py
@@ -1,0 +1,43 @@
+import pytest_mock
+
+
+class _FakeStream:
+    """A stdout/stderr stand-in that hands out queued byte chunks one read at a time."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = list(chunks)
+
+    def read(self) -> bytes:
+        return self.chunks.pop(0) if self.chunks else b""
+
+    def fileno(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeProc:
+    """A `subprocess.Popen` stand-in that emits controlled output chunks through the read loop."""
+
+    def __init__(self, stdout_chunks: list[bytes], stderr_chunks: list[bytes]) -> None:
+        self.stdout = _FakeStream(stdout_chunks)
+        self.stderr = _FakeStream(stderr_chunks)
+        self.returncode = 0
+
+    def poll(self) -> int | None:
+        # Keep the read loop going while either stream still has queued chunks.
+        return None if (self.stdout.chunks or self.stderr.chunks) else 0
+
+    def communicate(self) -> tuple[bytes, bytes]:
+        return b"", b""
+
+
+def patch_fake_proc(
+    mocker: pytest_mock.MockerFixture,
+    *,
+    stdout_chunks: list[bytes],
+    stderr_chunks: list[bytes] | None = None,
+) -> None:
+    proc = _FakeProc(stdout_chunks, stderr_chunks or [])
+    mocker.patch("src.runner.subprocess.Popen", return_value=proc)

--- a/tests/fake_proc.py
+++ b/tests/fake_proc.py
@@ -37,7 +37,7 @@ def patch_fake_proc(
     mocker: pytest_mock.MockerFixture,
     *,
     stdout_chunks: list[bytes],
-    stderr_chunks: list[bytes] | None = None,
+    stderr_chunks: list[bytes],
 ) -> None:
     proc = _FakeProc(stdout_chunks, stderr_chunks or [])
     mocker.patch("src.runner.subprocess.Popen", return_value=proc)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,12 +11,12 @@ import subprocess
 import tempfile
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any
 
 from tests.fake_proc import patch_fake_proc
 
 if TYPE_CHECKING:
-    from collections.abc import Buffer
+    from _typeshed import ReadableBuffer
 
 import pytest
 import pytest_mock
@@ -337,8 +337,7 @@ def test_output_decoding_custom_decoder(mocker: pytest_mock.MockerFixture) -> No
     class _AppendADecoder(codecs.IncrementalDecoder):
         # Custom decoder adding 'a' to each byte.
 
-        @override
-        def decode(self, input: Buffer, final: bool = False) -> str:
+        def decode(self, input: ReadableBuffer, final: bool = False) -> str:  # noqa: A002, FBT001, FBT002, ARG002
             return "".join(f"{byte:c}a" for byte in bytes(input))
 
     # 'hi' -> 'h','a','i','a'

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,13 +2,19 @@
 Test the default runner, `shpyx.run`.
 """
 
+from __future__ import annotations
+
+import codecs
 import platform
 import signal
 import subprocess
 import tempfile
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Buffer
 
 import pytest
 import pytest_mock
@@ -305,3 +311,76 @@ def test_unix_raw_enabled() -> None:
     )
     assert result.return_code == 123
     assert result.all_output == stderr_by_platform[_SYSTEM]
+
+
+class _FakeStream:
+    """A stdout/stderr stand-in that hands out queued byte chunks one read at a time."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = list(chunks)
+
+    def read(self) -> bytes:
+        return self.chunks.pop(0) if self.chunks else b""
+
+    def fileno(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeProc:
+    """A `subprocess.Popen` stand-in that emits controlled output chunks through the read loop."""
+
+    def __init__(self, stdout_chunks: list[bytes], stderr_chunks: list[bytes]) -> None:
+        self.stdout = _FakeStream(stdout_chunks)
+        self.stderr = _FakeStream(stderr_chunks)
+        self.returncode = 0
+
+    def poll(self) -> int | None:
+        # Keep the read loop going while either stream still has queued chunks.
+        return None if (self.stdout.chunks or self.stderr.chunks) else 0
+
+    def communicate(self) -> tuple[bytes, bytes]:
+        return b"", b""
+
+
+def _patch_fake_proc(
+    mocker: pytest_mock.MockerFixture,
+    *,
+    stdout_chunks: list[bytes],
+    stderr_chunks: list[bytes] | None = None,
+) -> None:
+    proc = _FakeProc(stdout_chunks, stderr_chunks or [])
+    mocker.patch("src.runner.subprocess.Popen", return_value=proc)
+
+
+def test_output_decoding(mocker: pytest_mock.MockerFixture) -> None:
+    """
+    Decoding must gracefully handle two separate hazards in a single run:
+
+      1. A valid multibyte UTF-8 character split across two output stream reads.
+      2. A genuinely invalid UTF-8 byte in the output (e.g. binary/Latin-1 data).
+    """
+    # '€' is b"\xe2\x82\xac". Split it across two reads, then feed a lone invalid byte (b"\xff").
+    _patch_fake_proc(mocker, stdout_chunks=[b"\xe2\x82", b"\xac", b"\xff"])
+
+    result = shpyx.run("dummy_cmd")
+    assert result.stdout == "€�"
+    assert result.stderr == ""
+
+
+def test_output_decoding_custom_decoder(mocker: pytest_mock.MockerFixture) -> None:
+    """A custom decoder factory supplied to `run` overrides the default decoding."""
+
+    class _AppendADecoder(codecs.IncrementalDecoder):
+        """A deliberately silly decoder: emit each byte as a character followed by an 'a'."""
+
+        def decode(self, input: Buffer, final: bool = False) -> str:  # noqa: A002, FBT001, FBT002, ARG002
+            return "".join(f"{byte:c}a" for byte in bytes(input))
+
+    # 'hi' -> 'h','a','i','a'
+    _patch_fake_proc(mocker, stdout_chunks=[b"hi"])
+
+    result = shpyx.run("dummy_cmd", decoder_factory=_AppendADecoder)
+    assert result.stdout == "haia"  # cspell:ignore haia

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -318,7 +318,6 @@ def test_unix_raw_enabled() -> None:
 def test_output_decoding(mocker: pytest_mock.MockerFixture) -> None:
     """
     Decoding must gracefully handle two separate hazards in a single run:
-
       1. A valid multibyte UTF-8 character split across two output stream reads.
       2. A genuinely invalid UTF-8 byte in the output (e.g. binary/Latin-1 data).
     """
@@ -331,10 +330,12 @@ def test_output_decoding(mocker: pytest_mock.MockerFixture) -> None:
 
 
 def test_output_decoding_custom_decoder(mocker: pytest_mock.MockerFixture) -> None:
-    """A custom decoder factory supplied to `run` overrides the default decoding."""
+    """
+    Test the `decoder_factory` argument.
+    """
 
     class _AppendADecoder(codecs.IncrementalDecoder):
-        """A deliberately silly decoder: emit each byte as a character followed by an 'a'."""
+        # Custom decoder adding 'a' to each byte.
 
         @override
         def decode(self, input: Buffer, final: bool = False) -> str:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Buffer
+    from _typeshed import ReadableBuffer
 
 import pytest
 import pytest_mock
@@ -376,7 +376,7 @@ def test_output_decoding_custom_decoder(mocker: pytest_mock.MockerFixture) -> No
     class _AppendADecoder(codecs.IncrementalDecoder):
         """A deliberately silly decoder: emit each byte as a character followed by an 'a'."""
 
-        def decode(self, input: Buffer, final: bool = False) -> str:  # noqa: A002, FBT001, FBT002, ARG002
+        def decode(self, input: ReadableBuffer, final: bool = False) -> str:  # noqa: A002, FBT001, FBT002, ARG002
             return "".join(f"{byte:c}a" for byte in bytes(input))
 
     # 'hi' -> 'h','a','i','a'

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,10 +11,12 @@ import subprocess
 import tempfile
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
+
+from tests.fake_proc import patch_fake_proc
 
 if TYPE_CHECKING:
-    from _typeshed import ReadableBuffer
+    from collections.abc import Buffer
 
 import pytest
 import pytest_mock
@@ -313,48 +315,6 @@ def test_unix_raw_enabled() -> None:
     assert result.all_output == stderr_by_platform[_SYSTEM]
 
 
-class _FakeStream:
-    """A stdout/stderr stand-in that hands out queued byte chunks one read at a time."""
-
-    def __init__(self, chunks: list[bytes]) -> None:
-        self.chunks = list(chunks)
-
-    def read(self) -> bytes:
-        return self.chunks.pop(0) if self.chunks else b""
-
-    def fileno(self) -> int:
-        return 0
-
-    def close(self) -> None:
-        pass
-
-
-class _FakeProc:
-    """A `subprocess.Popen` stand-in that emits controlled output chunks through the read loop."""
-
-    def __init__(self, stdout_chunks: list[bytes], stderr_chunks: list[bytes]) -> None:
-        self.stdout = _FakeStream(stdout_chunks)
-        self.stderr = _FakeStream(stderr_chunks)
-        self.returncode = 0
-
-    def poll(self) -> int | None:
-        # Keep the read loop going while either stream still has queued chunks.
-        return None if (self.stdout.chunks or self.stderr.chunks) else 0
-
-    def communicate(self) -> tuple[bytes, bytes]:
-        return b"", b""
-
-
-def _patch_fake_proc(
-    mocker: pytest_mock.MockerFixture,
-    *,
-    stdout_chunks: list[bytes],
-    stderr_chunks: list[bytes] | None = None,
-) -> None:
-    proc = _FakeProc(stdout_chunks, stderr_chunks or [])
-    mocker.patch("src.runner.subprocess.Popen", return_value=proc)
-
-
 def test_output_decoding(mocker: pytest_mock.MockerFixture) -> None:
     """
     Decoding must gracefully handle two separate hazards in a single run:
@@ -363,7 +323,7 @@ def test_output_decoding(mocker: pytest_mock.MockerFixture) -> None:
       2. A genuinely invalid UTF-8 byte in the output (e.g. binary/Latin-1 data).
     """
     # '€' is b"\xe2\x82\xac". Split it across two reads, then feed a lone invalid byte (b"\xff").
-    _patch_fake_proc(mocker, stdout_chunks=[b"\xe2\x82", b"\xac", b"\xff"])
+    patch_fake_proc(mocker, stdout_chunks=[b"\xe2\x82", b"\xac", b"\xff"])
 
     result = shpyx.run("dummy_cmd")
     assert result.stdout == "€�"
@@ -376,11 +336,12 @@ def test_output_decoding_custom_decoder(mocker: pytest_mock.MockerFixture) -> No
     class _AppendADecoder(codecs.IncrementalDecoder):
         """A deliberately silly decoder: emit each byte as a character followed by an 'a'."""
 
-        def decode(self, input: ReadableBuffer, final: bool = False) -> str:  # noqa: A002, FBT001, FBT002, ARG002
+        @override
+        def decode(self, input: Buffer, final: bool = False) -> str:
             return "".join(f"{byte:c}a" for byte in bytes(input))
 
     # 'hi' -> 'h','a','i','a'
-    _patch_fake_proc(mocker, stdout_chunks=[b"hi"])
+    patch_fake_proc(mocker, stdout_chunks=[b"hi"])
 
     result = shpyx.run("dummy_cmd", decoder_factory=_AppendADecoder)
-    assert result.stdout == "haia"  # cspell:ignore haia
+    assert result.stdout == "haia"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -323,7 +323,7 @@ def test_output_decoding(mocker: pytest_mock.MockerFixture) -> None:
       2. A genuinely invalid UTF-8 byte in the output (e.g. binary/Latin-1 data).
     """
     # '€' is b"\xe2\x82\xac". Split it across two reads, then feed a lone invalid byte (b"\xff").
-    patch_fake_proc(mocker, stdout_chunks=[b"\xe2\x82", b"\xac", b"\xff"])
+    patch_fake_proc(mocker, stdout_chunks=[b"\xe2\x82", b"\xac", b"\xff"], stderr_chunks=[])
 
     result = shpyx.run("dummy_cmd")
     assert result.stdout == "€�"
@@ -341,7 +341,7 @@ def test_output_decoding_custom_decoder(mocker: pytest_mock.MockerFixture) -> No
             return "".join(f"{byte:c}a" for byte in bytes(input))
 
     # 'hi' -> 'h','a','i','a'
-    patch_fake_proc(mocker, stdout_chunks=[b"hi"])
+    patch_fake_proc(mocker, stdout_chunks=[b"hi"], stderr_chunks=[])
 
     result = shpyx.run("dummy_cmd", decoder_factory=_AppendADecoder)
     assert result.stdout == "haia"


### PR DESCRIPTION
# What?
Fix an issue with output decoding which resulted in `UnicodeDecodeError` in two different cases:

1. **Split multibyte char** — the read loop uses non-blocking reads that grab whatever bytes sit in the pipe, with no alignment to character boundaries. A valid char like `€` (`b"\xe2\x82\xac"`) can arrive as `b"\xe2\x82"` on one read and `b"\xac"` on the next; each half fails to decode. Timing-dependent, so it surfaced as flaky crashes.
2. **Invalid bytes** ([#49](https://github.com/Apakottur/shpyx/issues/49)) — genuinely malformed UTF-8 in the output (binary/Latin-1 data) crashed regardless of chunking.

# How?
1. Use a decoder which collects bytes incrementally and ignores invalid characters.
2. Add initial support for custom decoders.